### PR TITLE
Force Synthea to export STU3 FHIR

### DIFF
--- a/src/main/java/com/digitalservices/dhp/dhpsyntheaservice/domain/SyntheaCommand.java
+++ b/src/main/java/com/digitalservices/dhp/dhpsyntheaservice/domain/SyntheaCommand.java
@@ -40,6 +40,8 @@ public class SyntheaCommand {
         List<String> options = new ArrayList<>();
         options.add("/bin/sh");
         options.add("run_synthea");
+        options.add("--exporter.fhir_stu3.export");
+        options.add("true");
         if (this.populationSize != null && !this.populationSize.trim().isEmpty()) {
             options.add(POPULATION);
             options.add(this.populationSize);


### PR DESCRIPTION
Due to hard-coded Bundle types in the FileManager.java file,
ensure that Synthea receives a command line argument to export FHIR STU3.