### PR TITLE
Switch to R4 for FHIR objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     implementation 'com.google.code.gson:gson:2.8.2'
-    implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:3.1.0'
-    implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:3.1.0'
+    implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:3.8.0'
+    implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:3.8.0'
 	implementation 'io.springfox:springfox-swagger2:2.9.2'
 	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 	

--- a/src/main/java/com/digitalservices/dhp/dhpsyntheaservice/domain/SyntheaCommand.java
+++ b/src/main/java/com/digitalservices/dhp/dhpsyntheaservice/domain/SyntheaCommand.java
@@ -40,8 +40,6 @@ public class SyntheaCommand {
         List<String> options = new ArrayList<>();
         options.add("/bin/sh");
         options.add("run_synthea");
-        options.add("--exporter.fhir_stu3.export");
-        options.add("true");
         if (this.populationSize != null && !this.populationSize.trim().isEmpty()) {
             options.add(POPULATION);
             options.add(this.populationSize);

--- a/src/main/java/com/digitalservices/dhp/dhpsyntheaservice/util/FileManager.java
+++ b/src/main/java/com/digitalservices/dhp/dhpsyntheaservice/util/FileManager.java
@@ -6,10 +6,10 @@ import ca.uhn.fhir.parser.IParser;
 import com.digitalservices.dhp.dhpsyntheaservice.domain.FileMetaData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Enumerations;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Condition;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Condition;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -83,7 +83,7 @@ public class FileManager {
             LOG.error(e);
             return new Bundle();
         }
-        FhirContext fhirContext = FhirContext.forDstu3();
+        FhirContext fhirContext = FhirContext.forR4();
         IParser parser = fhirContext.newJsonParser();
         Bundle bundle = parser.parseResource(Bundle.class, fileReader);
         return bundle;


### PR DESCRIPTION
Switch the libraries and frameworks to accept R4 FHIR files from the Synthea
tool.  Remove the parts of the command that force Synthea to use DSTU3.