### PR TITLE
Switch to OSEHRA Synthea image

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -1,4 +1,4 @@
-FROM robcaruso/synthea:1
+FROM osehra/synthea
 ARG env
 RUN rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y gradle
 ENV profile=${env}

--- a/synthea_base/Dockerfile
+++ b/synthea_base/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:11-jdk-stretch
+RUN apt-get update
+RUN apt-get install -y git
+RUN mkdir synthea
+COPY . /synthea
+ENV GRADLE_OPTS=-Xmx512m
+WORKDIR /synthea
+RUN ./gradlew build -x test
+WORKDIR /

--- a/synthea_base/README.rst
+++ b/synthea_base/README.rst
@@ -1,0 +1,29 @@
+Building the Synthea Docker Image
+=================================
+
+This folder contains the necessary Dockerfile which is used to create
+the Synthea image that is used in the creation of the DHP Synthea
+Service container for OSEHRA's Synthea compose scripts.
+
+Building the Synthea Image
++++++++++++++++++++++++++++
+
+The steps to build the image are quite simple.
+1. First, acquire the Synthea source code from GitHub using Git:
+
+..parsed-literal::
+
+  $ git clone https://github.com/synthetichealth/synthea.git
+  
+Or via download:
+
+  https://github.com/synthetichealth/synthea/archive/master.zip
+  
+2. Place the ``Dockerfile`` from this directory into the Synthea
+   directory
+3. Execute the Docker build command:
+
+..parsed-literal::
+
+  $ docker build -t osehra/synthea .
+  


### PR DESCRIPTION
Switch to using a Synthea image created and kept in the DockerHub account
for OSEHRA.  Add instructions on creating a local instance of the Synthea
Docker image.